### PR TITLE
Реализован экран добавления записи о приеме лекарства

### DIFF
--- a/lib/data/take_record/take_record_storage_impl.dart
+++ b/lib/data/take_record/take_record_storage_impl.dart
@@ -1,0 +1,12 @@
+import 'package:medicine_chest/entities/take_record.dart';
+import 'package:medicine_chest/ui/dependencies/take_record_storage.dart';
+
+class TakeRecordStorageImpl extends TakeRecordStorage{
+  @override
+  Future<int> saveTakeRecord(TakeRecord record) async {
+    // TODO implement saving to the database
+    return 0;
+  }
+
+
+}

--- a/lib/entities/take_record.dart
+++ b/lib/entities/take_record.dart
@@ -1,0 +1,23 @@
+import 'package:medicine_chest/entities/medicine.dart';
+import 'package:medicine_chest/entities/medicine_pack.dart';
+
+class TakeRecord {
+  static const int NO_ID = -1;
+
+  int id;
+  Medicine medicine;
+  DateTime takeTime;
+
+  Map<MedicinePack, double> takeAmountByPack;
+
+  TakeRecord(this.id, this.medicine, this.takeTime, this.takeAmountByPack);
+
+  double getTakenAmount() {
+    double result = 0.0;
+    takeAmountByPack.forEach((_, amount){
+      result += amount;
+    }); 
+    return result;
+  }
+
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,12 @@ import 'package:medicine_chest/data/database_creator.dart';
 import 'package:medicine_chest/data/medicine/medicine_pack_storage_impl.dart';
 import 'package:medicine_chest/data/medicine/medicine_storage_impl.dart';
 import 'package:medicine_chest/data/scheme/scheme_storage_impl.dart';
+import 'package:medicine_chest/data/take_record/take_record_storage_impl.dart';
 import 'package:medicine_chest/ui/add_sheme/add_scheme.dart';
 import 'package:medicine_chest/ui/dependencies/medicine_pack_storage.dart';
 import 'package:medicine_chest/ui/medicine_list/medicine_list.dart';
 import 'package:medicine_chest/ui/schemes_list/scheme_list.dart';
+import 'package:medicine_chest/ui/take_medicine/take_medicine.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -24,11 +26,13 @@ Future<void> main() async {
   final medicineStorageImpl = MedicineStorageImpl(database);
   final medicinePackStorageImpl = MedicinePackStorageImpl(database);
   final schemeStorageImpl = SchemeStorageImpl(database, medicineStorageImpl);
+  final takeRecordStorageImpl = TakeRecordStorageImpl();
 
   runApp(MyApp(
     medicinePackStorageImpl: medicinePackStorageImpl,
     medicineStorageImpl: medicineStorageImpl,
     schemeStorageImpl: schemeStorageImpl,
+    takeRecordStorageImpl:  takeRecordStorageImpl,
     ));
 }
 
@@ -36,12 +40,14 @@ class MyApp extends StatelessWidget {
   final MedicinePackStorage medicinePackStorageImpl;
   final MedicineStorageImpl medicineStorageImpl;
   final SchemeStorageImpl schemeStorageImpl;
+  final TakeRecordStorageImpl takeRecordStorageImpl;
 
   const MyApp(
       {super.key,
       required this.medicinePackStorageImpl,
       required this.medicineStorageImpl,
       required this.schemeStorageImpl,
+      required this.takeRecordStorageImpl,
       });
 
   @override
@@ -52,7 +58,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightBlueAccent),
         useMaterial3: true,
       ),
-      home: SchemeListPage(medicineStorageImpl, schemeStorageImpl),
+      home: TakeMedicinePage(medicineStorageImpl, medicinePackStorageImpl, takeRecordStorageImpl),
     );
   }
 }

--- a/lib/test/entities/take_medicine_distributor_test.dart
+++ b/lib/test/entities/take_medicine_distributor_test.dart
@@ -1,0 +1,65 @@
+import 'dart:ffi';
+import 'dart:math';
+
+import 'package:medicine_chest/entities/medicine_pack.dart';
+import 'package:medicine_chest/ui/take_medicine/take_medicine_distributor.dart';
+import 'package:test/test.dart';
+
+
+List<MedicinePack> _createPacks(List<int> expTime, List<double> leftAmount) {
+  List<MedicinePack> result = [];
+
+  for (int i = 0; i < expTime.length; i++) {
+    var curExpTime = expTime[i];
+    var curLeftAmount = leftAmount[i];
+    
+    result.add(MedicinePack(id: i, leftAmount: curLeftAmount, expirationTime: DateTime.fromMicrosecondsSinceEpoch(curExpTime)));
+  }
+
+  return result;
+}
+
+void main() {
+  group("One package", () {
+    test('Only one package test enough amount', () {
+        final takeAmount = 10.0;
+
+        var packs = _createPacks([23], [200]);
+        var result = TakeMedicineDistributor().getDistribution(packs, takeAmount);
+
+        expect(result.length, 1);
+        expect(result.values.first, takeAmount);
+    });
+
+    test('Only one package test not enought amount', () {
+        final takeAmount = 250.0;
+
+        var packs = _createPacks([23], [200]);
+
+        expect(() => TakeMedicineDistributor().getDistribution(packs, takeAmount), throwsA(isA<DistributionException>()));
+    });
+  });
+
+  test("Take all packs", () {
+      final takeAmount = 60.0;
+
+      var packs = _createPacks([1, 2, 3], [10, 20, 30]);
+      var result = TakeMedicineDistributor().getDistribution(packs, takeAmount);
+
+      expect(result.length, 3);
+      expect(result[packs[0]], 10);
+      expect(result[packs[1]], 20);
+      expect(result[packs[2]], 30);
+  });
+
+  test("Take by expiration time test", () {
+      final takeAmount = 15.0;
+
+      var packs = _createPacks([3, 2, 1], [30, 20, 10]);
+      var result = TakeMedicineDistributor().getDistribution(packs, takeAmount);
+
+      expect(result.length, 2);
+      expect(result[packs[2]], 10);
+      expect(result[packs[1]], 5);
+  });
+}

--- a/lib/ui/add_medicine_pack/medicine_select_or_create.dart
+++ b/lib/ui/add_medicine_pack/medicine_select_or_create.dart
@@ -100,22 +100,24 @@ class MedicineSelectOrCreateState extends State<MedicineSelectOrCreateWidget> {
 
 class MedicineSelectWidget extends StatefulWidget {
   MedicineStorage _medicineStorage;
+  ValueSetter<Medicine?>? onMedicineSetted = null;
 
-  MedicineSelectWidget(this._medicineStorage, {super.key});
+  MedicineSelectWidget(this._medicineStorage, {super.key, this.onMedicineSetted});
 
   @override
   State<StatefulWidget> createState() {
-    return MedicineSelectWidgetState(_medicineStorage);
+    return MedicineSelectWidgetState(_medicineStorage, onMedicineSetted: this.onMedicineSetted);
   }
 }
 
 class MedicineSelectWidgetState extends State<MedicineSelectWidget> {
   MedicineStorage _medicineStorage;
 
-  MedicineSelectWidgetState(this._medicineStorage);
+  MedicineSelectWidgetState(this._medicineStorage, {this.onMedicineSetted});
 
   List<Medicine>? _medicines = null;
   Medicine? _selectedMedicine = null;
+  ValueSetter<Medicine?>? onMedicineSetted = null;
 
   @override
   void initState() {
@@ -129,6 +131,7 @@ class MedicineSelectWidgetState extends State<MedicineSelectWidget> {
       _medicines = loadedMedicines;
       if (loadedMedicines.isNotEmpty) {
         _selectedMedicine = loadedMedicines.first;
+        onMedicineSetted?.call(_selectedMedicine);
       }
     });
   }
@@ -154,6 +157,7 @@ class MedicineSelectWidgetState extends State<MedicineSelectWidget> {
       onSelected: (value) {
         setState(() {
           _selectedMedicine = value;
+          onMedicineSetted?.call(_selectedMedicine);
         });
       },
       dropdownMenuEntries: _medicines!.map(_mapToMenuEntry).toList(),

--- a/lib/ui/dependencies/take_record_storage.dart
+++ b/lib/ui/dependencies/take_record_storage.dart
@@ -1,0 +1,6 @@
+import 'package:medicine_chest/entities/take_record.dart';
+
+abstract class TakeRecordStorage {
+
+  Future<int> saveTakeRecord(TakeRecord record);
+}

--- a/lib/ui/shared/date_picker_text_field.dart
+++ b/lib/ui/shared/date_picker_text_field.dart
@@ -63,6 +63,7 @@ class DatePickerTextFieldState extends State<DatePickerTextField> {
             }
           });
         },
+        readOnly: true,
         decoration:
             InputDecoration(border: UnderlineInputBorder(), labelText: label));
   }

--- a/lib/ui/shared/time_picker_text_field.dart
+++ b/lib/ui/shared/time_picker_text_field.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class TimePickerTextField extends StatefulWidget {
+  final String? label;
+  final TimeOfDay? initalTime;
+  final ValueSetter<TimeOfDay>? timeSetted;
+
+  TimePickerTextField({super.key, this.label, this.initalTime, this.timeSetted});
+
+  @override
+  State<StatefulWidget> createState() {
+    return TimePickerTextFieldState.create(label, timeSetted, initalTime);
+  }
+}
+
+class TimePickerTextFieldState extends State<TimePickerTextField> {
+  final String? _label;
+  final ValueSetter<TimeOfDay>? _onTimeSetted;
+  TimeOfDay _selectedTime;
+
+  TimePickerTextFieldState._internal(this._label, this._onTimeSetted, this._selectedTime);
+
+  factory TimePickerTextFieldState.create(String? label, ValueSetter<TimeOfDay>? onTimeSetted, TimeOfDay? initalTime) {
+      TimeOfDay selectedTime = initalTime ?? TimeOfDay.now();
+      return TimePickerTextFieldState._internal(label, onTimeSetted, selectedTime);
+  }
+
+  final TextEditingController _textFieldController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _textFieldController.text = _formatTime(_selectedTime);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+        controller: _textFieldController,
+        onTap: () async {
+          TimeOfDay? timeOfDay = await showTimePicker(context: context, initialTime: _selectedTime);
+          setState(() {
+            if (timeOfDay != null) {
+              _selectedTime = timeOfDay;
+              _textFieldController.text = _formatTime(_selectedTime);
+              _onTimeSetted?.call(timeOfDay);
+            }
+          });
+        },
+        readOnly: true,
+        decoration:
+            InputDecoration(border: UnderlineInputBorder(), labelText: _label));
+  }
+
+  String _formatTime(TimeOfDay? timeOfDay) {
+    if (timeOfDay != null) {
+      var partFormat = NumberFormat("00");
+      final hourString = partFormat.format(timeOfDay.hour);
+      final minutesString = partFormat.format(timeOfDay.minute);
+      return "$hourString:$minutesString";
+    } else {
+      return "";
+    }
+  }
+}
+ 

--- a/lib/ui/take_medicine/packs_selection_widget.dart
+++ b/lib/ui/take_medicine/packs_selection_widget.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:medicine_chest/entities/medicine.dart';
+import 'package:medicine_chest/entities/medicine_pack.dart';
+import 'package:medicine_chest/ui/dependencies/medicine_pack_storage.dart';
+import 'package:medicine_chest/ui/take_medicine/selectable_medicine_pack.dart';
+
+class MedicinePackSelectionWidget extends StatefulWidget {
+  MedicinePackStorage _medicinePackStorage;
+
+  Medicine _medicine;
+
+  ValueSetter<Set<MedicinePack>>? onSelectedPacksUpdated;
+
+  MedicinePackSelectionWidget(this._medicine, this._medicinePackStorage,
+      {super.key, this.onSelectedPacksUpdated});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _MedicinePackSelectionState(
+      _medicinePackStorage,
+      _medicine,
+      onSelectedPacksUpdated,
+    );
+  }
+}
+
+class _MedicinePackSelectionState extends State<MedicinePackSelectionWidget> {
+  MedicinePackStorage _medicinePackStorage;
+  Medicine _medicine;
+
+  List<MedicinePack>? _packs = null;
+  ValueSetter<Set<MedicinePack>>? _onSelectedPacksUpdated;
+  Set<MedicinePack> _selectedMedicinePacks = {};
+
+  _MedicinePackSelectionState(
+      this._medicinePackStorage, this._medicine, this._onSelectedPacksUpdated);
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPacks();
+  }
+
+  void _loadPacks() async {
+    List<MedicinePack> packs =
+        await _medicinePackStorage.getMedicinePacksByMedicine(_medicine);
+    packs.sort(
+        (pack1, pack2) => pack1.expirationTime.compareTo(pack2.expirationTime));
+    setState(() {
+      _packs = packs;
+      if (packs.isNotEmpty) {
+        addPackToSelection(packs[0]);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_packs == null) {
+      return _loading();
+    } else {
+      return _mainContent(_packs!);
+    }
+  }
+
+  Widget _loading() {
+    return Text("Идет загрузка");
+  }
+
+  Widget _mainContent(List<MedicinePack> medicinePacks) {
+    if (medicinePacks.isNotEmpty) {
+      return _list(medicinePacks);
+    } else {
+      return Text("Отсуствуют упаковки для выбранного лекарства");
+    }
+  }
+
+  Widget _list(List<MedicinePack> medicinePacks) {
+    return ListView.builder(
+      itemBuilder: (context, index) {
+        if (index > 0) {
+          return _packItem(medicinePacks[index - 1]);
+        } else {
+          return Padding(
+              padding: EdgeInsets.only(bottom: 8.0),
+              child: _totalSelectedSection(context));
+        }
+      },
+      shrinkWrap: true,
+      physics: NeverScrollableScrollPhysics(),
+      itemCount: medicinePacks.length + 1,
+    );
+  }
+
+  Widget _totalSelectedSection(BuildContext context) {
+    return RichText(
+      text: TextSpan(
+        style: DefaultTextStyle.of(context).style,
+        children: [
+          TextSpan(text: "Суммарный остаток в выбранных упаковках: "),
+          TextSpan(
+              text: _getSelectedTotalAmount().toStringAsFixed(2),
+              style: TextStyle(fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _packItem(MedicinePack medicinePack) {
+    var isSelected = _selectedMedicinePacks.contains(medicinePack);
+
+    var item = SelectableMedicinePackWidget(medicinePack, isSelected, () {
+      if (_selectedMedicinePacks.contains(medicinePack)) {
+        removePackFromSelection(medicinePack);
+      } else {
+        addPackToSelection(medicinePack);
+      }
+    });
+    return Column(children: [
+      Padding(padding: EdgeInsets.symmetric(vertical: 4), child: item),
+      Divider()
+    ]);
+  }
+
+  void addPackToSelection(MedicinePack pack) {
+    setState(() {
+      _selectedMedicinePacks.add(pack);
+      _onSelectedPacksUpdated?.call({..._selectedMedicinePacks});
+    });
+  }
+
+  void removePackFromSelection(MedicinePack pack) {
+    setState(() {
+      _selectedMedicinePacks.remove(pack);
+      _onSelectedPacksUpdated?.call({..._selectedMedicinePacks});
+    });
+  }
+
+  double _getSelectedTotalAmount() {
+    var result = 0.0;
+    for (var selectedPack in _selectedMedicinePacks) {
+      result += selectedPack.leftAmount;
+    }
+    return result;
+  }
+}

--- a/lib/ui/take_medicine/selectable_medicine_pack.dart
+++ b/lib/ui/take_medicine/selectable_medicine_pack.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:medicine_chest/entities/medicine_pack.dart';
+
+class SelectableMedicinePackWidget extends StatelessWidget {
+  MedicinePack _medicinePack;
+  bool _isSelected;
+  VoidCallback _onCheckBoxClick;
+
+  SelectableMedicinePackWidget(
+      this._medicinePack, this._isSelected, this._onCheckBoxClick,
+      {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [_mainColumn(context), _checkBox()]);
+  }
+
+  Widget _mainColumn(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _title(),
+        _leftAmount(context),
+        _validUntil(context),
+      ],
+    );
+  }
+
+  Widget _checkBox() {
+    return Checkbox(
+        value: _isSelected, onChanged: (value) => {_onCheckBoxClick()});
+  }
+
+  Widget _title() {
+    var titleString = "Упаковка #${_medicinePack.id}";
+    return Text(
+      titleString,
+      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+    );
+  }
+
+  Widget _leftAmount(BuildContext context) {
+    return RichText(
+      text: TextSpan(
+        style: DefaultTextStyle.of(context).style,
+        children: [
+          TextSpan(text: "Остаток: "),
+          TextSpan(
+              text: _medicinePack.leftAmount.toStringAsFixed(2),
+              style: TextStyle(fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+
+  Widget _validUntil(BuildContext context) {
+    var dateFormat = DateFormat("dd.MM.yyyy");
+    var validUntilString = dateFormat.format(_medicinePack.expirationTime);
+
+    return RichText(
+      text: TextSpan(
+        style: DefaultTextStyle.of(context).style,
+        children: [
+          TextSpan(text: "Годен до: "),
+          TextSpan(
+              text: validUntilString,
+              style: TextStyle(fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/take_medicine/take_medicine.dart
+++ b/lib/ui/take_medicine/take_medicine.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:intl/intl.dart';
+import 'package:medicine_chest/entities/medicine.dart';
+import 'package:medicine_chest/entities/medicine_pack.dart';
+import 'package:medicine_chest/entities/take_record.dart';
+import 'package:medicine_chest/ui/add_medicine_pack/medicine_select_or_create.dart';
+import 'package:medicine_chest/ui/dependencies/medicine_pack_storage.dart';
+import 'package:medicine_chest/ui/dependencies/medicine_storage.dart';
+import 'package:medicine_chest/ui/dependencies/take_record_storage.dart';
+import 'package:medicine_chest/ui/shared/date_picker_text_field.dart';
+import 'package:medicine_chest/ui/shared/time_picker_text_field.dart';
+import 'package:medicine_chest/ui/take_medicine/packs_selection_widget.dart';
+import 'package:medicine_chest/ui/take_medicine/take_medicine_distributor.dart';
+
+class TakeMedicinePage extends StatefulWidget {
+  MedicineStorage _medicineStorage;
+  MedicinePackStorage _medicinePackStorage;
+  TakeRecordStorage _takeRecordStorage;
+
+  TakeMedicinePage(
+      this._medicineStorage, this._medicinePackStorage, this._takeRecordStorage,
+      {super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _TakeMedicinePage(
+        _medicineStorage, _medicinePackStorage, _takeRecordStorage);
+  }
+}
+
+class _TakeMedicinePage extends State<TakeMedicinePage> {
+  MedicineStorage _medicineStorage;
+  MedicinePackStorage _medicinePackStorage;
+  TakeRecordStorage _takeRecordStorage;
+
+  _TakeMedicinePage(this._medicineStorage, this._medicinePackStorage,
+      this._takeRecordStorage);
+
+  final _formKey = GlobalKey<FormState>();
+  final _dosageSizeController = TextEditingController();
+
+  var _takeDate = DateTime.now();
+  var _takeTime = TimeOfDay.now();
+  Medicine? _selectedMedicine = null;
+  Set<MedicinePack> _selectedPacks = {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          title: Text("Принять лекарство"),
+        ),
+        body: RawScrollbar(
+            child: SingleChildScrollView(child: _mainContent(context))),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => {_onSaveClicked()},
+          child: const Icon(Icons.check),
+        ));
+  }
+
+  Widget _mainContent(BuildContext context) {
+    return Padding(
+        padding: EdgeInsets.only(left: 16.0, right: 16.0, top: 8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _medicineSelector(),
+            _spaceBetweenInputs(),
+            _creationDate(),
+            _spaceBetweenInputs(),
+            _creationTime(),
+            _spaceBetweenInputs(),
+            _dosageSizeWidget(),
+            _spaceBetweenInputs(),
+            _packsSectionTitle(context),
+            _packSelectionWidget(context),
+          ],
+        ));
+  }
+
+  Widget _medicineSelector() {
+    return MedicineSelectWidget(
+      _medicineStorage,
+      onMedicineSetted: (value) => {
+        setState(() {
+          _selectedMedicine = value;
+        })
+      },
+    );
+  }
+
+  Widget _creationDate() {
+    return DatePickerTextField(
+        label: "Дата приема",
+        initialDate: _takeDate,
+        minDateTime: null,
+        maxDateTime: null,
+        dateTimeSetted: (newDateTime) => {
+              setState(() {
+                _takeDate = newDateTime;
+              })
+            });
+  }
+
+  Widget _creationTime() {
+    return TimePickerTextField(
+      label: "Время приема",
+      initalTime: _takeTime,
+      timeSetted: (newTime) => {
+        setState(() {
+          _takeTime = newTime;
+        })
+      },
+    );
+  }
+
+  Widget _dosageSizeWidget() {
+    return Form(
+        key: _formKey,
+        child: TextFormField(
+            validator: (value) {
+              var valueWithoutSpaces = value?.replaceAll(" ", "");
+              if (valueWithoutSpaces == null || valueWithoutSpaces.isEmpty) {
+                return "Необходимо указать размер дозы";
+              }
+
+              var amountLeft = _parseDosageLeft(value);
+              if (amountLeft == null) {
+                return "Размер дозы должен быть числом";
+              }
+              return null;
+            },
+            controller: _dosageSizeController,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+                border: UnderlineInputBorder(), labelText: 'Размер дозы')));
+  }
+
+  double? _parseDosageLeft(String? dosage) {
+    if (dosage == null) {
+      return null;
+    } else {
+      var amountWithoutSpaces = dosage.replaceAll(" ", "");
+      return NumberFormat().tryParse(amountWithoutSpaces)?.toDouble();
+    }
+  }
+
+  Widget _packsSectionTitle(BuildContext context) {
+    var textColor = Theme.of(context).colorScheme.primary;
+    return Text("Выберите упаковки лекарства",
+        style: TextStyle(
+            fontSize: 18, color: textColor, fontWeight: FontWeight.bold));
+  }
+
+  Widget _packSelectionWidget(BuildContext context) {
+    if (_selectedMedicine == null) {
+      return SizedBox.shrink();
+    } else {
+      return Padding(
+          padding: EdgeInsets.only(top: 0.0),
+          child: MedicinePackSelectionWidget(
+              _selectedMedicine!, _medicinePackStorage,
+              onSelectedPacksUpdated: (packs) => {_selectedPacks = packs}));
+    }
+  }
+
+  Widget _spaceBetweenInputs() {
+    return SizedBox(height: 10);
+  }
+
+  DateTime _getTakeTime() {
+    return _takeDate.copyWith(hour: _takeTime.hour, minute: _takeTime.minute);
+  }
+
+  void _onSaveClicked() async {
+    if (_formKey.currentState?.validate() == true &&
+        _selectedMedicine != null) {
+      double? oneTakeAmount = _parseDosageLeft(_dosageSizeController.text);
+      if (oneTakeAmount == null) {
+        return;
+      }
+      DateTime takeTime = _getTakeTime();
+
+      final packsDistributor = TakeMedicineDistributor();
+      Map<MedicinePack, double>? takeAmountByPack;
+      try {
+        takeAmountByPack = packsDistributor.getDistribution(
+            _selectedPacks.toList(), oneTakeAmount);
+      } on DistributionException catch (e) {
+        Fluttertoast.showToast(
+          msg: e.message,
+          toastLength: Toast.LENGTH_SHORT,
+          gravity: ToastGravity.BOTTOM,
+          textColor: Colors.white,
+          fontSize: 16.0);
+        return;
+      }
+
+      TakeRecord takeRecord = TakeRecord(
+          TakeRecord.NO_ID, _selectedMedicine!, takeTime, takeAmountByPack);
+
+      await _takeRecordStorage.saveTakeRecord(takeRecord);
+
+      Fluttertoast.showToast(
+          msg: "Лекарство принято",
+          toastLength: Toast.LENGTH_SHORT,
+          gravity: ToastGravity.BOTTOM,
+          textColor: Colors.white,
+          fontSize: 16.0);
+    }
+  }
+}

--- a/lib/ui/take_medicine/take_medicine_distributor.dart
+++ b/lib/ui/take_medicine/take_medicine_distributor.dart
@@ -1,0 +1,41 @@
+import 'dart:math';
+
+import 'package:medicine_chest/entities/medicine_pack.dart';
+
+class DistributionException implements Exception {
+  final String message;
+  
+  DistributionException(this.message);
+  
+  @override
+  String toString() => 'DistributionException: $message';
+}
+
+class TakeMedicineDistributor {
+
+  Map<MedicinePack, double> getDistribution(List<MedicinePack> packs, double amount) {
+    List<MedicinePack> sortedByExpTime = [...packs];
+    
+    sortedByExpTime.sort((p1, p2) => p1.expirationTime.compareTo(p2.expirationTime));
+    double takenAmount = 0;
+    int index = 0;
+    Map<MedicinePack, double> result = {};
+
+    while (takenAmount < amount && index < packs.length) {
+      MedicinePack pack = sortedByExpTime[index];
+
+      double curTakeAmount = min(amount - takenAmount, pack.leftAmount) ;
+
+      result[pack] = curTakeAmount;
+      takenAmount += curTakeAmount;
+      index++;
+    }
+
+    if (takenAmount < amount) {
+      throw DistributionException("Выбранных упаковок не хватает лекарства");
+    }
+
+    return result;
+  }
+  
+}


### PR DESCRIPTION
![Screenshot_1725807836](https://github.com/user-attachments/assets/f1d9c020-3a60-4afd-bf75-951e41f78c64)


Экран поддерживает прием лекарства сразу из нескольких упаковок, на случай если в какой-то упаковке не хватает необходимого количества лекарства.

После того, как пользователь выбрал набор упаковок из которых будет принимать текущую дозу лекарства, приложение само набирает дозу из выбранных упаковок. При этом выбор происходит жадно: приоритет отдается лекарствам, у которых срок годности истечет быстрее всего. Алгоритм набора дозы из упаковок лекарств реализован в классе `TakeMedicineDistributor`. Для этого класса разработан набор unit-тестов.
 
Сохранение записи в базу данных будет реализовано в отдельном merge request