### PR TITLE
Исправлено состояние гонки при получении записей о приеме лекарств

### DIFF
--- a/lib/data/medicine/medicine_pack_storage_impl.dart
+++ b/lib/data/medicine/medicine_pack_storage_impl.dart
@@ -70,7 +70,8 @@ class MedicinePackStorageImpl implements MedicinePackStorage {
 
 
   Future<void> applyMedicineTake(Map<MedicinePack, double> amount, Transaction txn) async {
-    amount.forEach((pack, packAmount) async {
+    for (var pack in amount.keys) {
+      var packAmount = amount[pack]!;
       MedicinePack? actualPack = await _getMedicinePackById(pack.id, txn);
       if (actualPack != null) {
         double newAmount = actualPack.leftAmount - packAmount;
@@ -79,7 +80,7 @@ class MedicinePackStorageImpl implements MedicinePackStorage {
         };
         txn.update(_tableName, values, where: "id = ?", whereArgs: [actualPack.id]);
       }
-    });
+    }
   }
 
   MedicinePack _convertToMedicinePack(Map<String, Object?> data) {

--- a/lib/data/take_record/take_record_storage_impl.dart
+++ b/lib/data/take_record/take_record_storage_impl.dart
@@ -64,7 +64,8 @@ class TakeRecordStorageImpl extends TakeRecordStorage {
   Future<Map<MedicinePack, double>> _getTakeAmountByJson(String json) async {
     Map<String, dynamic> decodedMap = jsonDecode(json);
     Map<MedicinePack, double> result = {};
-    decodedMap.forEach((key, value) async {
+    for (var key in decodedMap.keys) {
+      var value = decodedMap[key];
       var packId = int.tryParse(key);
       if (packId != null) {
         MedicinePack? medicinePack = await _medicinePackStorageImpl.getById(packId);
@@ -74,7 +75,7 @@ class TakeRecordStorageImpl extends TakeRecordStorage {
           }
         }
       }
-    });
+    }
     return result;
   }
 


### PR DESCRIPTION
```dart
decodedMap.forEach((key, value) async) {});
```

При использовании такой конструкции, вычисление элементов внутри forEach может происходить, после возвращения результата из функции. Это приводило к состоянию гонки, и багу при подсчете количества принятых лекарств.

Фикс переходит на стандарный цикл for, вместо использования forEach